### PR TITLE
notMember

### DIFF
--- a/classy-prelude/ClassyPrelude/Classes.hs
+++ b/classy-prelude/ClassyPrelude/Classes.hs
@@ -94,6 +94,8 @@ instance (CanDeleteVal c' k, c ~ c') => CanDelete (k -> c -> c') where
 
 class CanMember c k | c -> k where
     member :: k -> c -> Prelude.Bool
+    notMember :: k -> c -> Prelude.Bool
+    notMember k = Prelude.not . member k
 
 class CanReadFile a where
     readFile :: F.FilePath -> a


### PR DESCRIPTION
I myself am really not sure about this one, since the effect of this function is easily achievable using the general `not` function, but on the other hand `notMember` is exported by all standard modules, which export `member`. 

This could be a question of philosophy behind the library and which conventions we set with it.
