### PR TITLE
Added a type class and instance for replicateM_

### DIFF
--- a/classy-prelude/ClassyPrelude.hs
+++ b/classy-prelude/ClassyPrelude.hs
@@ -38,6 +38,7 @@ module ClassyPrelude
     , forM
     , forM_
     , replicateM
+    , replicateM_
     , stripPrefix
     , isPrefixOf
     , stripSuffix

--- a/classy-prelude/ClassyPrelude/Classes.hs
+++ b/classy-prelude/ClassyPrelude/Classes.hs
@@ -51,6 +51,9 @@ class CanMapM_ ci i | ci -> i where
 class CanReplicateM c i len | c -> i len where
     replicateM :: Monad m => len -> m i -> m c
 
+class CanReplicateM_ i len where
+    replicateM_ :: Monad m => len -> m i -> m ()
+
 class CanLookup c k v | c -> k v where
     lookup :: k -> c -> Maybe v
 

--- a/classy-prelude/ClassyPrelude/List.hs
+++ b/classy-prelude/ClassyPrelude/List.hs
@@ -102,6 +102,9 @@ instance CanReplicate [i] i Int where
 instance CanReplicateM [a] a Int where
     replicateM = Monad.replicateM
 
+instance CanReplicateM_ a Int where
+    replicateM_ = Monad.replicateM_
+
 instance CanFind [a] a where
     find = List.find
 


### PR DESCRIPTION
Because there is both `mapM` and `mapM_`, but not both `replicateM` and `replicateM_`.
