### PR TITLE
Add CanReadFile and CanWriteFile instances for Text and LText

### DIFF
--- a/classy-prelude/ClassyPrelude/LText.hs
+++ b/classy-prelude/ClassyPrelude/LText.hs
@@ -12,6 +12,7 @@ import qualified Data.Text.Lazy as LText
 import qualified Data.Text.Lazy.IO as LText
 import qualified Data.Text.Lazy.Encoding as LText
 import qualified Data.Text.Encoding.Error as Text
+import qualified Filesystem.Path.CurrentOS as FilePath
 
 
 instance CanMap LText LText Char Char where
@@ -39,6 +40,12 @@ instance CanIntersperse LText Char where
 instance CanStripPrefix LText where
     stripPrefix = LText.stripPrefix
     isPrefixOf = LText.isPrefixOf
+
+instance CanReadFile LText where
+    readFile = liftIO . LText.readFile . FilePath.encodeString
+
+instance CanWriteFile LText where
+    writeFile fp = liftIO . LText.writeFile (FilePath.encodeString fp)
 
 instance CanBreak LText Char where
     break = LText.break

--- a/classy-prelude/ClassyPrelude/Text.hs
+++ b/classy-prelude/ClassyPrelude/Text.hs
@@ -12,6 +12,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text
 import qualified Data.Text.IO as Text
+import qualified Filesystem.Path.CurrentOS as FilePath
 
 
 instance CanMap Text Text Char Char where
@@ -42,6 +43,12 @@ instance CanIntersperse Text Char where
 instance CanStripPrefix Text where
     stripPrefix = Text.stripPrefix
     isPrefixOf = Text.isPrefixOf
+
+instance CanReadFile Text where
+    readFile = liftIO . Text.readFile . FilePath.encodeString
+
+instance CanWriteFile Text where
+    writeFile fp = liftIO . Text.writeFile (FilePath.encodeString fp)
 
 instance CanBreak Text Char where
     break = Text.break


### PR DESCRIPTION
I have used classy-prelude for a little project and missed instances of CanReadFile and CanWriteFile for Text. This is a patch that adds instances for Text and lazy Text.
