### PR TITLE
Introduce groupBy' and fix #53

### DIFF
--- a/classy-prelude/ClassyPrelude.hs
+++ b/classy-prelude/ClassyPrelude.hs
@@ -83,7 +83,9 @@ module ClassyPrelude
     , sortBy
     , sortWith
     , group
+    , group'
     , groupBy
+    , groupBy'
     , groupWith
     , cons
     , uncons
@@ -300,8 +302,8 @@ sortWith f = sortBy $ comparing f
 -- input list and then to form groups by equality on these projected elements
 --
 -- Inspired by <http://hackage.haskell.org/packages/archive/base/latest/doc/html/GHC-Exts.html#v:groupWith>
-groupWith :: (CanGroupBy c a, Eq b) => (a -> b) -> c -> [c]
-groupWith f = groupBy (\a b -> f a == f b)
+groupWith :: (CanGroupBy' c a, Eq b) => (a -> b) -> c -> [c]
+groupWith f = groupBy' (\a b -> f a == f b)
 
 -- | We define our own @undefined@ which is marked as deprecated. This makes it
 -- useful to use during development, but let's you more easily getting

--- a/classy-prelude/ClassyPrelude/Classes.hs
+++ b/classy-prelude/ClassyPrelude/Classes.hs
@@ -210,10 +210,22 @@ class CanCompareLength c where
 class CanGroupBy c a | c -> a where
     groupBy :: (a -> a -> Bool) -> c -> [c]
 
+class CanGroupBy' c a | c -> a where
+    -- | Similar to standard 'groupBy', but operates on the whole collection, 
+    -- not just the consecutive items.
+    groupBy' :: (a -> a -> Bool) -> c -> [c]
+
 class CanGroup c a | c -> a where
     group :: c -> [c]
     default group :: (CanGroupBy c a, Eq a) => c -> [c]
     group = groupBy (==)
+
+class CanGroup' c a | c -> a where
+    -- | Similar to standard 'group', but operates on the whole collection, 
+    -- not just the consecutive items.
+    group' :: c -> [c]
+    default group' :: (CanGroupBy' c a, Eq a) => c -> [c]
+    group' = groupBy' (==)
 
 class CanRepeat c a | c -> a where
     repeat :: a -> c

--- a/classy-prelude/ClassyPrelude/List.hs
+++ b/classy-prelude/ClassyPrelude/List.hs
@@ -155,8 +155,16 @@ instance CanCompareLength [a] where
 instance CanGroupBy [a] a where
     groupBy = List.groupBy
 
+instance CanGroupBy' [a] a where
+    groupBy' f (head : tail) = let
+      (matches, nonMatches) = partition (f head) tail
+      in (head : matches) : groupBy' f nonMatches
+    groupBy' _ [] = []
+
 instance Eq a => CanGroup [a] a where
     group = List.group
+
+instance Eq a => CanGroup' [a] a
 
 instance CanRepeat [a] a where
     repeat = List.repeat


### PR DESCRIPTION
`groupBy'` performs grouping the way it turned out to be expected by many from `groupBy` in the discussion of issue #53. This pull request also rebases the implementation of `groupWith` on `groupBy'`, thus fixing the aforementioned issue.
