### PR TITLE
Increase lower bound for mono-traversable

### DIFF
--- a/classy-prelude/classy-prelude.cabal
+++ b/classy-prelude/classy-prelude.cabal
@@ -24,7 +24,7 @@ library
                      , unordered-containers
                      , hashable
                      , lifted-base                   >= 0.2
-                     , mono-traversable              >= 0.2
+                     , mono-traversable              >= 0.3
                      , semigroups
                      , vector-instances
                      , old-locale


### PR DESCRIPTION
If I am not mistaken, `cabal install classy-prelude´  is currently failing with:

```
ClassyPrelude.hs:143:8:
    Could not find module `Data.MinLen'
```

It looks like it needs `mono-traversable >= 0.3`
