### PR TITLE
add putText and putTextLn

### DIFF
--- a/classy-prelude/ClassyPrelude.hs
+++ b/classy-prelude/ClassyPrelude.hs
@@ -122,6 +122,8 @@ module ClassyPrelude
       -- ** IO
     , IOData (..)
     , print
+    , putText
+    , putTextLn
     , hClose
       -- ** FilePath
     , fpToString
@@ -168,7 +170,9 @@ import Data.IOData (IOData (..))
 import Control.Monad.Catch (MonadThrow (throwM))
 
 import Data.Vector.Instances ()
-import CorePrelude hiding (print, undefined, (<>), catMaybes)
+import CorePrelude hiding (print, putStrLn, undefined, (<>), catMaybes)
+import qualified CorePrelude
+import qualified Data.Text.IO
 import Data.ChunkedZip
 import qualified Data.Char as Char
 import Data.Sequences
@@ -381,6 +385,12 @@ asSVector = id
 print :: (Show a, MonadIO m) => a -> m ()
 print = liftIO . Prelude.print
 
+putText :: MonadIO m => Text -> m ()
+putText = liftIO . Data.Text.IO.putStr
+
+putTextLn :: (MonadIO m) => Text -> m ()
+putTextLn = liftIO . Data.Text.IO.putStrLn
+
 -- | Sort elements using the user supplied function to project something out of
 -- each element.
 -- Inspired by <http://hackage.haskell.org/packages/archive/base/latest/doc/html/GHC-Exts.html#v:sortWith>.
@@ -438,7 +448,7 @@ fpToTextWarn :: MonadIO m => FilePath -> m Text
 fpToTextWarn fp = case F.toText fp of
     Right ok -> return ok
     Left bad -> do
-        putStrLn $ pack $ "non-unicode filepath: " ++ F.encodeString fp
+        CorePrelude.putStrLn $ pack $ "non-unicode filepath: " ++ F.encodeString fp
         return bad
 
 -- | Translates a FilePath to a Text

--- a/classy-prelude/test/main.hs
+++ b/classy-prelude/test/main.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 import Test.Hspec
 import Test.Hspec.QuickCheck
@@ -13,7 +14,6 @@ import Test.QuickCheck.Arbitrary
 import Prelude (asTypeOf, fromIntegral, undefined)
 import qualified Prelude
 import Control.Monad.Trans.Writer (tell, Writer, runWriter)
-import Data.Functor.Identity (runIdentity)
 import Control.Concurrent (throwTo, threadDelay, forkIO)
 import Control.Exception (throw)
 import qualified Data.Set as Set
@@ -404,6 +404,12 @@ main = hspec $ do
                     | Just DummyException <- fromException e -> return ()
                     | otherwise -> error "Expected a DummyException"
                 Right () -> error "Expected an exception" :: IO ()
+    describe "printing" $
+      it "compiles" $ ((do
+        print ("foo"::String)
+        putText "foo"
+        putTextLn "foo"
+        ) :: IO ())
 
 data DummyException = DummyException
     deriving (Show, Typeable)


### PR DESCRIPTION
I would like to change putStr to accept either String or Text. However, for putStr that would require either an explicit type signature or extended default rules, so using a different name putText seems better.

But CorePrelude already exports putStrLn that only takes Text, so maybe it is better to follow that convention?
