### PR TITLE
yesod: don't import yesod-newsfeed or persistent

### DIFF
--- a/classy-prelude-yesod/ClassyPrelude/Yesod.hs
+++ b/classy-prelude-yesod/ClassyPrelude/Yesod.hs
@@ -9,9 +9,6 @@ import ClassyPrelude.Conduit as X
 import Yesod as X hiding (Header, parseTime)
 import qualified Yesod
 import Yesod.Static as X
-import Yesod.Feed as X
 import Network.HTTP.Client.Conduit as X
 import Network.HTTP.Types as X
-import Database.Persist.Sql as X (SqlBackend, SqlPersistT)
-import Database.Persist.Sql as X (runMigration)
 import Data.Default as X (Default (..))

--- a/classy-prelude-yesod/classy-prelude-yesod.cabal
+++ b/classy-prelude-yesod/classy-prelude-yesod.cabal
@@ -1,5 +1,5 @@
 name:                classy-prelude-yesod
-version:             0.10.2
+version:             0.11
 synopsis:            Provide a classy prelude including common Yesod functionality.
 description:         This is an extension of classy-prelude-conduit, adding in commonly used functions and data types from Yesod.
 homepage:            https://github.com/snoyberg/classy-prelude
@@ -17,10 +17,8 @@ library
                      , classy-prelude >= 0.10.2 && < 0.10.3
                      , classy-prelude-conduit >= 0.10.2 && < 0.10.3
                      , yesod >= 1.2
-                     , yesod-newsfeed
                      , yesod-static
                      , http-types
                      , http-conduit
-                     , persistent >= 1.1
                      , aeson
                      , data-default


### PR DESCRIPTION
Note the version bump here: that makes it no longer correspond to classy-prelude. This is now confusing because the library started off tracking versions.

This library now saves 6 lines over putting it directly into Import.hs, and users will have to dig a bit deeper to find out how things are getting imported.
