### PR TITLE
Re-generalize intercalate

### DIFF
--- a/classy-prelude/ClassyPrelude.hs
+++ b/classy-prelude/ClassyPrelude.hs
@@ -192,7 +192,7 @@ import Data.Vector.Instances ()
 import CorePrelude hiding (print, undefined, (<>), catMaybes, first, second)
 import Data.ChunkedZip
 import qualified Data.Char as Char
-import Data.Sequences hiding (elem)
+import Data.Sequences hiding (elem, intercalate)
 import Data.MonoTraversable
 import Data.Containers
 import Data.Builder
@@ -372,10 +372,8 @@ intersect = intersection
 unions :: (MonoFoldable c, SetContainer (Element c)) => c -> Element c
 unions = ofoldl' union Monoid.mempty
 
-#if !MIN_VERSION_mono_traversable(0, 9, 3)
-intercalate :: (Monoid (Element c), IsSequence c) => Element c -> c -> Element c
+intercalate :: (SemiSequence seq, Monoid (Element seq)) => Element seq -> seq -> Element seq
 intercalate xs xss = concat (intersperse xs xss)
-#endif
 
 asByteString :: ByteString -> ByteString
 asByteString = id


### PR DESCRIPTION
Refs #118

Also got rid of all the CPP given that the cabal file defines a lower
bound of mono-traversable 0.9.3 anyway.

`intersperse` has a `SemiSequence` constraint, so I can't see how to
make this any more general. Also, I'm not familiar enough with rewrite
rules to be able to write any, sorry.