### PR TITLE
Add concurrency-related exports from lifted-base.

### DIFF
--- a/classy-prelude/ClassyPrelude.hs
+++ b/classy-prelude/ClassyPrelude.hs
@@ -75,6 +75,39 @@ module ClassyPrelude
     , stdin
     , stdout
     , stderr
+      -- * Concurrency
+      -- ** Concurrent Haskell
+    , ThreadId
+      -- ** Basic concurrency operations
+    , myThreadId
+    , fork
+    , forkWithUnmask
+    , forkFinally
+    , killThread
+    , throwTo
+      -- ** Threads with affinity
+    , forkOn
+    , forkOnWithUnmask
+    , getNumCapabilities
+    , setNumCapabilities
+    , threadCapability
+      -- ** Scheduling
+    , yieldThread
+      -- ** Waiting
+    , threadDelay
+    , threadWaitRead
+    , threadWaitWrite
+      -- ** Communication abstractions
+    , module Control.Concurrent.QSem.Lifted
+    , module Control.Concurrent.QSemN.Lifted
+      -- ** Bound Threads
+    , rtsSupportsBoundThreads
+    , forkOS
+    , isCurrentThreadBound
+    , runInBoundThread
+    , runInUnboundThread
+      -- ** Weak references to ThreadIds
+    , mkWeakThreadId
       -- * Non-standard
       -- ** List-like classes
     , map
@@ -175,8 +208,11 @@ import Data.Functor
 import Control.Exception (assert)
 import Control.Exception.Enclosed
 import Control.Monad (when, unless, void, liftM, ap, forever, join, replicateM_, guard, MonadPlus (..), (=<<), (>=>), (<=<), liftM2, liftM3, liftM4, liftM5)
+import Control.Concurrent.Lifted
 import Control.Concurrent.MVar.Lifted
 import Control.Concurrent.Chan.Lifted
+import Control.Concurrent.QSem.Lifted
+import Control.Concurrent.QSemN.Lifted
 import Control.Concurrent.STM hiding (atomically, always, alwaysSucceeds, retry, orElse, check)
 import qualified Control.Concurrent.STM as STM
 import Data.IORef.Lifted
@@ -186,6 +222,7 @@ import Data.Traversable (Traversable (..), for, forM)
 import Data.Foldable (Foldable)
 import Data.IOData (IOData (..))
 import Control.Monad.Catch (MonadThrow (throwM), MonadCatch, MonadMask)
+import Control.Monad.Base
 
 import Data.Vector.Instances ()
 import CorePrelude hiding (print, undefined, (<>), catMaybes, first, second)
@@ -509,6 +546,11 @@ traceShowId a = trace (show a) a
 -- Since 0.5.9
 traceShowM :: (Show a, Monad m) => a -> m ()
 traceShowM = traceM . show
+
+-- | Generalized version of 'yield'.
+yieldThread :: MonadBase IO m => m ()
+yieldThread = yield
+{-# INLINE yieldThread #-}
 
 fpToString :: FilePath -> String
 fpToString = id

--- a/classy-prelude/ClassyPrelude.hs
+++ b/classy-prelude/ClassyPrelude.hs
@@ -76,38 +76,8 @@ module ClassyPrelude
     , stdout
     , stderr
       -- * Concurrency
-      -- ** Concurrent Haskell
-    , ThreadId
-      -- ** Basic concurrency operations
-    , myThreadId
-    , fork
-    , forkWithUnmask
-    , forkFinally
-    , killThread
-    , throwTo
-      -- ** Threads with affinity
-    , forkOn
-    , forkOnWithUnmask
-    , getNumCapabilities
-    , setNumCapabilities
-    , threadCapability
-      -- ** Scheduling
+    , module Control.Concurrent.Lifted
     , yieldThread
-      -- ** Waiting
-    , threadDelay
-    , threadWaitRead
-    , threadWaitWrite
-      -- ** Communication abstractions
-    , module Control.Concurrent.QSem.Lifted
-    , module Control.Concurrent.QSemN.Lifted
-      -- ** Bound Threads
-    , rtsSupportsBoundThreads
-    , forkOS
-    , isCurrentThreadBound
-    , runInBoundThread
-    , runInUnboundThread
-      -- ** Weak references to ThreadIds
-    , mkWeakThreadId
       -- * Non-standard
       -- ** List-like classes
     , map
@@ -208,11 +178,10 @@ import Data.Functor
 import Control.Exception (assert)
 import Control.Exception.Enclosed
 import Control.Monad (when, unless, void, liftM, ap, forever, join, replicateM_, guard, MonadPlus (..), (=<<), (>=>), (<=<), liftM2, liftM3, liftM4, liftM5)
-import Control.Concurrent.Lifted
+import Control.Concurrent.Lifted hiding (yield)
+import qualified Control.Concurrent.Lifted as Conc (yield)
 import Control.Concurrent.MVar.Lifted
 import Control.Concurrent.Chan.Lifted
-import Control.Concurrent.QSem.Lifted
-import Control.Concurrent.QSemN.Lifted
 import Control.Concurrent.STM hiding (atomically, always, alwaysSucceeds, retry, orElse, check)
 import qualified Control.Concurrent.STM as STM
 import Data.IORef.Lifted
@@ -547,9 +516,9 @@ traceShowId a = trace (show a) a
 traceShowM :: (Show a, Monad m) => a -> m ()
 traceShowM = traceM . show
 
--- | Generalized version of 'yield'.
+-- | Originally 'Conc.yield'.
 yieldThread :: MonadBase IO m => m ()
-yieldThread = yield
+yieldThread = Conc.yield
 {-# INLINE yieldThread #-}
 
 fpToString :: FilePath -> String

--- a/classy-prelude/classy-prelude.cabal
+++ b/classy-prelude/classy-prelude.cabal
@@ -40,6 +40,7 @@ library
                      , bifunctors
                      , mutable-containers >= 0.3 && < 0.4
                      , dlist >= 0.7
+                     , transformers-base
   ghc-options:         -Wall -fno-warn-orphans
 
 test-suite test

--- a/classy-prelude/test/main.hs
+++ b/classy-prelude/test/main.hs
@@ -378,22 +378,22 @@ main = hspec $ do
             failed <- newIORef 0
             tid <- forkIO $ do
                 catchAny
-                    (threadDelay 20000)
+                    (Control.Concurrent.threadDelay 20000)
                     (const $ writeIORef failed 1)
                 writeIORef failed 2
-            threadDelay 10000
-            throwTo tid DummyException
-            threadDelay 50000
+            Control.Concurrent.threadDelay 10000
+            Control.Concurrent.throwTo tid DummyException
+            Control.Concurrent.threadDelay 50000
             didFail <- readIORef failed
             liftIO $ didFail `shouldBe` (0 :: Int)
         it "tryAny" $ do
             failed <- newIORef False
             tid <- forkIO $ do
-                _ <- tryAny $ threadDelay 20000
+                _ <- tryAny $ Control.Concurrent.threadDelay 20000
                 writeIORef failed True
-            threadDelay 10000
-            throwTo tid DummyException
-            threadDelay 50000
+            Control.Concurrent.threadDelay 10000
+            Control.Concurrent.throwTo tid DummyException
+            Control.Concurrent.threadDelay 50000
             didFail <- readIORef failed
             liftIO $ didFail `shouldBe` False
         it "tryAnyDeep" $ do


### PR DESCRIPTION
As mentioned in issue #121 , I added the concurrency-related exports from `lifted-base`, so `classy-prelude` users won't need to import `base` to write thread related stuff.

There is only one name conflict, `yield` in `Control.Concurrent.Lifted` conflicts with the one in `Conduit`, so it is renamed to `yieldThread`, and the `Control.Concurrent.Lifted` exports are hand-written.