### PR TITLE
Add export for monad-loops

### DIFF
--- a/classy-prelude/ClassyPrelude.hs
+++ b/classy-prelude/ClassyPrelude.hs
@@ -18,6 +18,7 @@ module ClassyPrelude
     , module Control.Applicative
       -- ** Monad
     , module Control.Monad
+    , module Control.Monad.Loops
     , whenM
     , unlessM
       -- ** Mutable references
@@ -178,6 +179,7 @@ import Data.Functor
 import Control.Exception (assert)
 import Control.Exception.Enclosed
 import Control.Monad (when, unless, void, liftM, ap, forever, join, replicateM_, guard, MonadPlus (..), (=<<), (>=>), (<=<), liftM2, liftM3, liftM4, liftM5)
+import Control.Monad.Loops
 import Control.Concurrent.Lifted hiding (yield)
 import qualified Control.Concurrent.Lifted as Conc (yield)
 import Control.Concurrent.MVar.Lifted

--- a/classy-prelude/classy-prelude.cabal
+++ b/classy-prelude/classy-prelude.cabal
@@ -41,6 +41,7 @@ library
                      , mutable-containers >= 0.3 && < 0.4
                      , dlist >= 0.7
                      , transformers-base
+                     , monad-loops
   ghc-options:         -Wall -fno-warn-orphans
 
 test-suite test


### PR DESCRIPTION
I propose exporting monadic loop combinators from `monad-loops` package. The package is actively maintained and widely used, does not introduce extra dependencies, and the combinators are much more comprehensive than `whenM` and `unlessM` currently provided in `classy-prelude`.